### PR TITLE
Provide retry mechanism for failed MFA code; added extra command for removing credentials files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "azure-mgmt-compute >= 27.1.0",
     "azure-mgmt-subscription >= 3.0.0",
     "oauthlib >= 3.2.0",
+    "backoff >= 2.1.2", 
 ]
 
 

--- a/src/pyclvm/_common/session.py
+++ b/src/pyclvm/_common/session.py
@@ -24,13 +24,13 @@ class Credentials(jdict):
     Region: str
 
 
-def _make_file_name(profile: str) -> str:
+def make_file_name(profile: str) -> str:
     return f"aws-{profile}-credentials"
 
 
 def _read_credentials(profile: str) -> Optional[Credentials]:
     try:
-        credentials = fetch(_make_file_name(profile))
+        credentials = fetch(make_file_name(profile))
         expiration = datetime.fromisoformat(credentials.Expiration)
         return credentials if expiration > datetime.now(expiration.tzinfo) else None
     except FileNotFoundError:
@@ -53,7 +53,7 @@ def _store_credentials(profile: str, credentials: Credentials) -> None:
     credentials.Expiration = datetime.isoformat(
         credentials.Expiration
     )  # to make it json serializable
-    store(_make_file_name(profile), credentials)
+    store(make_file_name(profile), credentials)
 
 
 def _get_profile_credentials(profile: str, config: jdict) -> Credentials:

--- a/src/pyclvm/_common/user_data.py
+++ b/src/pyclvm/_common/user_data.py
@@ -3,40 +3,33 @@ User Data Access Utility
 Adopted from https://gist.github.com/jslay88/1fd8a8ba1d05ff2a4810520785a67891
 """
 import json
+import os
 import pathlib
-import sys
-from typing import Dict, Final
+from typing import Final
 
 from jdict import jdict, set_json_decoder
 
-_HOME: Final[pathlib.Path] = pathlib.Path.home()
-
-_SYSTEM_USER_DIR: Final[Dict[str, str]] = {
-    "win32": "AppData/Roaming",
-    "linux": ".local/share",
-    "darwin": "Library/Application Support",
-}
-
-_SYSTEM_CLVM_PATH: Final[pathlib.Path] = _HOME / _SYSTEM_USER_DIR[sys.platform] / "clvm"
+_SYSTEM_CLVM_PATH: Final[pathlib.Path] = os.path.expanduser("~/.clvm")
+SYSTEM_CLVM_PATH = pathlib.Path(_SYSTEM_CLVM_PATH)
 
 set_json_decoder(json)
 
-_SYSTEM_CLVM_PATH.mkdir(parents=True, exist_ok=True)
+SYSTEM_CLVM_PATH.mkdir(parents=True, exist_ok=True)
 
 
-def _get_path(name: str) -> pathlib.Path:
-    return _SYSTEM_CLVM_PATH / f"{name}.json"
+def get_credentials_file_path(name: str) -> pathlib.Path:
+    return SYSTEM_CLVM_PATH / f"{name}.json"
 
 
 def fetch(name: str) -> jdict:
-    with _get_path(name).open("r") as file:
+    with get_credentials_file_path(name).open("r") as file:
         return json.load(file)
 
 
 def store(name: str, data: jdict) -> None:
-    with _get_path(name).open("w") as file:
+    with get_credentials_file_path(name).open("w") as file:
         json.dump(data, file)
 
 
 def remove(name: str) -> None:
-    _get_path(name).unlink(missing_ok=True)
+    get_credentials_file_path(name).unlink(missing_ok=True)

--- a/src/pyclvm/ssm/__init__.py
+++ b/src/pyclvm/ssm/__init__.py
@@ -1,6 +1,7 @@
 """session manager utilities"""
 
 from . import session
+from .clear import clear
 from .shell import shell
 
-__all__ = ["shell", "session"]
+__all__ = ["shell", "session", "clear"]

--- a/src/pyclvm/ssm/clear.py
+++ b/src/pyclvm/ssm/clear.py
@@ -1,0 +1,25 @@
+import os
+
+from pyclvm._common.session import make_file_name
+from pyclvm._common.user_data import get_credentials_file_path
+
+
+def clear(**kwargs: str) -> None:
+    """
+    Clear stored session credentials.
+
+    Args:
+        **kwargs (str): Provide profile name
+
+    Returns:
+        None
+    """
+
+    profile_name = kwargs.get("profile", "default")
+    credentials_file = make_file_name(profile_name)
+    credentials_file_path = get_credentials_file_path(credentials_file)
+    try:
+        os.remove(credentials_file_path)
+        print("[INFO] Successfully removed stored credentials")
+    except FileNotFoundError:
+        print("[SKIPPED] as there is no such file or directory to be removed...")


### PR DESCRIPTION
# Change Summary

## Description

Fixed #97

New output:
```
$ clvm instance stop caios-dev-shako-desktop

Enter MFA Code: asdasdasdsd

 > Invalid MFA code provided, please try again!

Enter MFA Code: 123456

 > Invalid MFA code provided, please try again!

Enter MFA Code: 123

 > Invalid MFA code provided, please try again!

Enter MFA Code: asdasd

 > Giving up after multiple fails...
```

New clear command:

```
clvm ssm clear profile=default
[SKIPPED] as there is no such file or directory to be removed...
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

