### PR TITLE
issue-135. Off wait status on start/stop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "sshconf >= 0.2.3",
     "pycryptodome >= 3.14.1",
     "google-cloud-compute >= 1.3.2",
-    "ec2map == 1.0.4",
+    "ec2map >= 1.0.6",
     "singleton-decorator >= 1.0.0",
     "azure-core >= 1.24.1",
     "azure-common >= 1.1.28",

--- a/src/pyclvm/instance/start.py
+++ b/src/pyclvm/instance/start.py
@@ -70,8 +70,7 @@ def _is_stopped_or_terminated(
     instance: Union[Ec2InstanceProxy, GcpInstanceProxy, AzureInstanceProxy],
 ) -> None:
     print(f"Starting {instance_name} ...")
-    instance.start()
-    print(f"{instance_name} is running")
+    instance.start(wait=False)
 
 
 def _in_transition(

--- a/src/pyclvm/instance/stop.py
+++ b/src/pyclvm/instance/stop.py
@@ -75,8 +75,7 @@ def _stopping_instance(
     instance: Union[Ec2InstanceProxy, GcpInstanceProxy, AzureInstanceProxy],
 ) -> None:
     print(f"Stopping {instance_name} ...")
-    instance.stop()
-    print(f"{instance_name} stopped.")
+    instance.stop(wait=False)
 
 
 def _in_transition(


### PR DESCRIPTION
Small enhancement #135 
There's no need to wait a status on launching VM. It can be checked by "instance ls".