### PR TITLE
Refactor(ssh-new): Removed redundant output for ssh-new

### DIFF
--- a/scripts/type.sh
+++ b/scripts/type.sh
@@ -1,0 +1,5 @@
+
+#!/bin/sh -e
+set -x
+
+pytype --config=pytype.cfg src/*/*.py

--- a/src/pyclvm/ssh/new.py
+++ b/src/pyclvm/ssh/new.py
@@ -118,15 +118,13 @@ def _aws_config_lines(instance: Ec2RemoteShellProxy, **kwargs: str) -> List:
     }
     # ---
     instance.start(wait=True)
-    timeout = 10
-    while timeout > 0:
+    for _ in range(10, 0, -1):
         print(".", end="")
         time.sleep(1)
-        timeout -= 1
     print()
     # ---
     instance.execute(
-        "pip3 install --upgrade authk",
+        "pip3 install --upgrade authk --quiet",
         f'runuser -u ssm-user -- authk add "{pubkey}"',
         **kwargs,
     )


### PR DESCRIPTION
Fixes #189 

Description:
- Added `--quiet` flag to `pip install authk`
- Minor refactoring


- [x] Bug fix (non-breaking change which fixes an issue)
