### PR TITLE
[Changelog CI] Add Changelog for Version v1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# Version: v1.1.10
+
+* [2888655](https://github.com/BstLabs/py-clvm/commit/2888655d98afe7905f21b4a04592a50e1773baf8): Release PR v1.1.10 (#211)
+
+* Docs: Changed changelog type to commit messages
+
+* version bump v1.1.10 (stable)
+* [98b8a05](https://github.com/BstLabs/py-clvm/commit/98b8a054ad5ed3d852c56f86aaec73d848faf9d4): [Changelog CI] Add Changelog for Version v1.1.10b (#210)
+
+Co-authored-by: orkhanshirin <orkhan@blackswan-technologies.com>
+* [8077372](https://github.com/BstLabs/py-clvm/commit/80773727d2073c8dca7b47d2dbc2c3e93ef407ee): Docs(update): Modified and enhanced existing documentation (#209)
+
+* Docs(update): Modified and enhanced docs
+
+Description:
+- Removed redundant checklist from PR template
+- Applied new changelog workflow and config for it
+- Added new indicator badges to README for:
+	- PyPi version,
+	- License,
+	- Changelog,
+	- Linter
+	- Type checker
+
+Co-authored-by: Dmitry Slobodchikov <zoosman@mail.ru>
+* [f8f56b5](https://github.com/BstLabs/py-clvm/commit/f8f56b5611e9a3697e8e62f325cc7e961e7178c4): Update CHANGELOG.md
+* [7cbd47c](https://github.com/BstLabs/py-clvm/commit/7cbd47ccba209cca9f8dfe0faedfa7403e41ff62): Docs(changelog): update release notes
+
+
 # Version: v1.1.10b
 
 


### PR DESCRIPTION
# Version: v1.1.10

* [2888655](https://github.com/BstLabs/py-clvm/commit/2888655d98afe7905f21b4a04592a50e1773baf8): Release PR v1.1.10 (#211)

* Docs: Changed changelog type to commit messages

* version bump v1.1.10 (stable)
* [98b8a05](https://github.com/BstLabs/py-clvm/commit/98b8a054ad5ed3d852c56f86aaec73d848faf9d4): [Changelog CI] Add Changelog for Version v1.1.10b (#210)

Co-authored-by: orkhanshirin <orkhan@blackswan-technologies.com>
* [8077372](https://github.com/BstLabs/py-clvm/commit/80773727d2073c8dca7b47d2dbc2c3e93ef407ee): Docs(update): Modified and enhanced existing documentation (#209)

* Docs(update): Modified and enhanced docs

Description:
- Removed redundant checklist from PR template
- Applied new changelog workflow and config for it
- Added new indicator badges to README for:
	- PyPi version,
	- License,
	- Changelog,
	- Linter
	- Type checker

Co-authored-by: Dmitry Slobodchikov <zoosman@mail.ru>
* [f8f56b5](https://github.com/BstLabs/py-clvm/commit/f8f56b5611e9a3697e8e62f325cc7e961e7178c4): Update CHANGELOG.md
* [7cbd47c](https://github.com/BstLabs/py-clvm/commit/7cbd47ccba209cca9f8dfe0faedfa7403e41ff62): Docs(changelog): update release notes
