### PR TITLE
Feat: Stop VM instance after VSCode close.

### DIFF
--- a/src/pyclvm/vscode/start.py
+++ b/src/pyclvm/vscode/start.py
@@ -4,6 +4,7 @@ from typing import Any, List
 
 import psutil
 from ec2instances.ec2_instance_mapping import Ec2RemoteShellMapping
+from plt import _get_os
 
 from pyclvm._common.azure_instance_mapping import AzureRemoteShellMapping
 from pyclvm._common.gcp_instance_mapping import GcpRemoteShellMapping
@@ -14,7 +15,6 @@ from pyclvm.plt import (
     _unsupported_platform,
 )
 
-from plt import _get_os
 
 def start(instance_name: str, **kwargs: str) -> None:
     """

--- a/src/pyclvm/vscode/start.py
+++ b/src/pyclvm/vscode/start.py
@@ -14,6 +14,7 @@ from pyclvm.plt import (
     _unsupported_platform,
 )
 
+from plt import _get_os
 
 def start(instance_name: str, **kwargs: str) -> None:
     """
@@ -47,7 +48,7 @@ def _start_vscode_with_given_platform(
 
 def _get_vscode_cmd(instance_name: str, path: str, _platform: str) -> List[str]:
     return [
-        "code",
+        "code.cmd" if "Windows" == _get_os() else "code",
         "--folder-uri",
         f"vscode-remote://ssh-remote+{instance_name}-{_platform.lower()}{path}",
     ]
@@ -76,10 +77,6 @@ def _run_subprocess(instance_name: str, _platform: str, **kwargs: str) -> None:
         ).stop(wait=False)
     except StopIteration:
         return
-
-
-def _get_path(**kwargs: str) -> str:
-    return kwargs.get("path", "/home")
 
 
 def _get_platform_instance(instance_name: str, _platform: str, **kwargs: str) -> Any:

--- a/src/pyclvm/vscode/start.py
+++ b/src/pyclvm/vscode/start.py
@@ -1,7 +1,8 @@
-import os
 import subprocess
+from time import sleep
 from typing import Any, List
 
+import psutil
 from ec2instances.ec2_instance_mapping import Ec2RemoteShellMapping
 
 from pyclvm._common.azure_instance_mapping import AzureRemoteShellMapping
@@ -41,8 +42,7 @@ def start(instance_name: str, **kwargs: str) -> None:
 def _start_vscode_with_given_platform(
     instance_name: str, _platform: str, **kwargs: str
 ) -> None:
-    _run_subprocess(instance_name, _get_path(**kwargs), _platform)
-    _get_platform_instance(instance_name, _platform, **kwargs)().start()
+    _run_subprocess(instance_name, _platform, **kwargs)
 
 
 def _get_vscode_cmd(instance_name: str, path: str, _platform: str) -> List[str]:
@@ -53,11 +53,29 @@ def _get_vscode_cmd(instance_name: str, path: str, _platform: str) -> List[str]:
     ]
 
 
-def _run_subprocess(instance_name: str, path: str, _platform: str) -> None:
-    cmd = _get_vscode_cmd(instance_name, path, _platform)
-    process = subprocess.Popen(args=cmd)
-    process.communicate()
-    os.environ["VSCODE_AWS_PROMPT"] = "True"
+def _run_subprocess(instance_name: str, _platform: str, **kwargs: str) -> None:
+    cmd = _get_vscode_cmd(
+        instance_name=instance_name,
+        path=kwargs.get("path", "/home"),
+        _platform=_platform,
+    )
+    vscode_proc_pid = subprocess.Popen(args=cmd).pid
+    sleep(120)  # 2 minutes timeout for switching directory at start
+    try:
+        ssh_proc = next(
+            p
+            for p in psutil.process_iter()
+            if p.pid > vscode_proc_pid
+            and "ssh" in p.name()
+            and next(cl for cl in p.cmdline() if instance_name in cl)
+        )
+        while psutil.pid_exists(ssh_proc.pid):
+            sleep(1)
+        _get_platform_instance(
+            instance_name=instance_name, _platform=_platform, **kwargs
+        ).stop(wait=False)
+    except StopIteration:
+        return
 
 
 def _get_path(**kwargs: str) -> str:
@@ -70,4 +88,4 @@ def _get_platform_instance(instance_name: str, _platform: str, **kwargs: str) ->
         "GCP": lambda: GcpRemoteShellMapping().get(instance_name),
         "AZURE": lambda: AzureRemoteShellMapping().get(instance_name),
     }
-    return platform_instance_map.get(_platform.upper())
+    return platform_instance_map.get(_platform.upper())()


### PR DESCRIPTION
# Stop VM instance after an SSH session is over.

## Generally VSCode stops SSH, and then VM should be stopped.


Fixes #215
